### PR TITLE
feat: externalize periodic capture trigger enable flag

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -86,6 +86,7 @@ jobs:
       TF_VAR_camera_address: ${{ secrets.TF_VAR_camera_address }}
       TF_VAR_credentials_user: ${{ secrets.TF_VAR_credentials_user }}
       TF_VAR_credentials_pass: ${{ secrets.TF_VAR_credentials_pass }}
+      TF_VAR_is_periodic_capture_enabled: ${{ secrets.TF_VAR_is_periodic_capture_enabled }}
 
     steps:
     # Checkout the repository to the GitHub Actions runner

--- a/infrastructure/app/resource.scheduler.tf
+++ b/infrastructure/app/resource.scheduler.tf
@@ -4,8 +4,9 @@ locals {
 
 resource "aws_cloudwatch_event_rule" "schedule" {
   name                = "schedule"
-  description         = "Schedule for Lambda Function"
+  description         = "Trigger video stream capture periodically"
   schedule_expression = local.schedule
+  is_enabled          = var.is_periodic_capture_enabled
 }
 
 resource "aws_cloudwatch_event_target" "schedule_lambda" {

--- a/infrastructure/app/variables.tf
+++ b/infrastructure/app/variables.tf
@@ -19,3 +19,7 @@ variable "credentials_pass" {
 variable "capture_analyzer_image_url" {
   type = string
 }
+
+variable "is_periodic_capture_enabled" {
+  type = bool
+}


### PR DESCRIPTION
After we collected data for 1 month and successfully trained the ML model, we don't need to have periodic image capture.
This code change is to externalize the flag of the scheduler, so we can turn it off in the environment configuration.